### PR TITLE
Rabbiveesh/cli flags

### DIFF
--- a/bin/lrrr
+++ b/bin/lrrr
@@ -70,9 +70,9 @@ GetOptions( \%opt,
 );
 
 if ( !$opt{ watch } ) {
-    $opt{ watch } = \[ qw( lib templates ) ];
+    $opt{ watch } = [ qw( lib templates ) ];
     if ( -f $ARGV[0] ) {
-        push @${$opt{watch}}, $ARGV[0];
+        push @{$opt{watch}}, $ARGV[0];
     }
 }
 
@@ -82,7 +82,7 @@ if ( my $e = load_class $backend_class ) {
     die "Could not find class $backend_class in \@INC (\@INC includes @INC)\n";
 }
 
-my $backend = $backend_class->new( watch => ${ $opt{watch} } );
+my $backend = $backend_class->new( watch => $opt{watch} );
 my $finished = 0;
 my $worker_pid = 0;
 my $modified = 1;

--- a/bin/lrrr
+++ b/bin/lrrr
@@ -59,9 +59,10 @@ use v5.16;
 use Mojo::Base -strict;
 use Mojo::Loader qw( load_class );
 use Pod::Usage qw( pod2usage );
-use Getopt::Long qw( GetOptions );
+use Getopt::Long qw( GetOptions Configure);
 use POSIX 'WNOHANG';
 
+Configure( 'require_order' );
 my %opt;
 GetOptions( \%opt,
     'watch|w=s@',

--- a/bin/lrrr
+++ b/bin/lrrr
@@ -75,7 +75,11 @@ if ( !$opt{ watch } ) {
     if ( -f $ARGV[0] ) {
         push @{$opt{watch}}, $ARGV[0];
     }
+} else {
+  #process csv
+  $opt{watch} = [ map { split /,/ } @{$opt{watch}} ]
 }
+
 
 my $backend_class = 'Mojo::Server::Morbo::Backend::' . ( $opt{backend} // $ENV{MOJO_MORBO_BACKEND} // 'Poll' );
 if ( my $e = load_class $backend_class ) {

--- a/bin/lrrr
+++ b/bin/lrrr
@@ -27,7 +27,7 @@ Choose a specific one by setting C<MOJO_MORBO_BACKEND>.
 
 =head2 C<-w>, C<--watch>
 
-A directory or directories to watch, seperated by commas. Defaults
+A directory or directories to watch, separated by commas. Defaults
 to the first argument (if it's a path to a file) and the C<lib>
 and C<templates> directories in the current directory.
 

--- a/bin/lrrr
+++ b/bin/lrrr
@@ -65,6 +65,7 @@ use POSIX 'WNOHANG';
 my %opt;
 GetOptions( \%opt,
     'watch|w=s@',
+    'backend|b=s',
     'help|h' => sub { pod2usage(1) },
 );
 
@@ -75,7 +76,7 @@ if ( !$opt{ watch } ) {
     }
 }
 
-my $backend_class = 'Mojo::Server::Morbo::Backend::' . ( $ENV{MOJO_MORBO_BACKEND} // 'Poll' );
+my $backend_class = 'Mojo::Server::Morbo::Backend::' . ( $opt{backend} // $ENV{MOJO_MORBO_BACKEND} // 'Poll' );
 if ( my $e = load_class $backend_class ) {
     die $e if ref $e;
     die "Could not find class $backend_class in \@INC (\@INC includes @INC)\n";

--- a/bin/lrrr
+++ b/bin/lrrr
@@ -4,7 +4,7 @@
 
 =head1 SYNOPSIS
 
-    lrrr [--watch|-w <dir>]... <command>
+    lrrr [--watch|-w <dir[,dir...]> --backend|-b]... <command>
     lrrr --help|-h
 
 =head1 DESCRIPTION
@@ -27,9 +27,15 @@ Choose a specific one by setting C<MOJO_MORBO_BACKEND>.
 
 =head2 C<-w>, C<--watch>
 
-A directory or directories to watch. Defaults to the first argument (if
-it's a path to a file) and the C<lib> and C<templates> directories in
-the current directory.
+A directory or directories to watch, seperated by commas. Defaults
+to the first argument (if it's a path to a file) and the C<lib>
+and C<templates> directories in the current directory.
+
+=head2 C<-b>, C<--backend>
+
+Choose a specific backend for watching file changes. The default
+is C<Poll> (L<Mojo::Server::Morbo::Backend::Poll>). Takes
+precedence over the C<MOJO_MORBO_BACKEND> environment variable.
 
 =head1 ENVIRONMENT
 


### PR DESCRIPTION
Hey, I added a -b flag to choose the backend without having to set an environment variable. This matches the options the morbo gives you.

In addition, the -w flag is currently broken, b/c it's meant to make an arrayref, and you were using an arrayref-ref. I fixed that, and will be adding parsing so that you can pass comma seperated values. I assume that's pretty standard. If you'd rather a different delimeter for the argument, lemme know, it's a minor change to make.

I also added the require_order option, so the command that's passed to lrrr can take command line options without lrrr eating them up.

I'll add documentation for the new flags, so don't merge this 'til it's ready.
